### PR TITLE
Fix checkout step1 layout problem

### DIFF
--- a/app/src/main/res/layout/item_buy_goods.xml
+++ b/app/src/main/res/layout/item_buy_goods.xml
@@ -26,7 +26,7 @@
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:orientation="vertical">
 
         <TextView

--- a/app/src/main/res/layout/item_checkout_review_goods.xml
+++ b/app/src/main/res/layout/item_checkout_review_goods.xml
@@ -18,7 +18,7 @@
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:gravity="center_vertical"
         android:orientation="vertical">
 


### PR DESCRIPTION
If the product name displays two lines, item layout will be cut.
