### PR TITLE
Fix Google sign out crash

### DIFF
--- a/app/src/main/java/com/kosbrother/mongmongwoo/login/GoogleSignInActivity.java
+++ b/app/src/main/java/com/kosbrother/mongmongwoo/login/GoogleSignInActivity.java
@@ -125,7 +125,9 @@ public class GoogleSignInActivity extends BaseLoginActivity implements
     }
 
     private void signOut() {
-        Auth.GoogleSignInApi.signOut(mGoogleApiClient);
+        if (mGoogleApiClient != null && mGoogleApiClient.isConnected()) {
+            Auth.GoogleSignInApi.signOut(mGoogleApiClient);
+        }
     }
 
     private User getUser(GoogleSignInAccount acct) {


### PR DESCRIPTION
When post user connect time out, call sign out method but GoogleApiClient is not connected.
